### PR TITLE
Made tests able to run with coverage graphs

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -23,6 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:cov": "react-scripts test --coverage --watchAll=false --collectCoverageFrom='src/Components/**/*.{js,jsx,ts,tsx}' --collectCoverageFrom='!src/Components/firebase.js'",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/code/package.json
+++ b/code/package.json
@@ -23,7 +23,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "test:cov": "react-scripts test --coverage --watchAll=false --collectCoverageFrom='src/Components/**/*.{js,jsx,ts,tsx}' --collectCoverageFrom='!src/Components/firebase.js'",
+    "test:cov": "react-scripts test --coverage --watchAll --collectCoverageFrom='src/Components/**/*.{js,jsx,ts,tsx}' --collectCoverageFrom='!src/Components/firebase.js'",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
I changed the package.json file to include npm run test:cov (like we have in our interactive textbook) so that when you run the tests the coverage graph shows up to give us a better idea of our coverage.